### PR TITLE
feat: add financial dashboard

### DIFF
--- a/ازياء قرطبة/src/App.tsx
+++ b/ازياء قرطبة/src/App.tsx
@@ -6,6 +6,7 @@ import { OrdersPage } from './components/OrdersPage';
 import { InvoicesPage } from './components/InvoicesPage';
 import { CustomersPage } from './components/CustomersPage';
 import { ReportsPage } from './components/ReportsPage';
+import { FinancialPage } from './components/FinancialPage';
 import { Toaster } from './components/ui/sonner';
 
 export default function App() {
@@ -38,6 +39,8 @@ export default function App() {
         return <CustomersPage />;
       case 'reports':
         return <ReportsPage />;
+      case 'financial':
+        return <FinancialPage />;
       default:
         return <Dashboard onNavigate={handleNavigate} />;
     }

--- a/ازياء قرطبة/src/App.tsx
+++ b/ازياء قرطبة/src/App.tsx
@@ -7,24 +7,253 @@ import { InvoicesPage } from './components/InvoicesPage';
 import { CustomersPage } from './components/CustomersPage';
 import { ReportsPage } from './components/ReportsPage';
 import { FinancialPage } from './components/FinancialPage';
+import { CustomerDetailsPage } from './components/CustomerDetailsPage';
 import { Toaster } from './components/ui/sonner';
+import { Customer } from './types/customer';
+
+const customersData: Customer[] = [
+  {
+    id: 1,
+    name: 'أحمد محمد العراقي',
+    phone: '07701234567',
+    address: 'بغداد، منطقة الكرخ',
+    totalSpent: 1250,
+    lastOrder: '2024-01-15',
+    label: 'ذهبي',
+    measurements: {
+      height: 142,
+      shoulder: 49,
+      waist: 44,
+      chest: 110,
+    },
+    orders: [
+      {
+        id: 'ORD-1024',
+        type: 'دشداشة ستايل كويتي',
+        status: 'جاهز',
+        orderDate: '2024-01-15',
+        deliveryDate: '2024-01-25',
+        total: 250,
+        paid: 200,
+      },
+      {
+        id: 'ORD-0987',
+        type: 'بدلة رسمية',
+        status: 'مسلم',
+        orderDate: '2023-12-05',
+        deliveryDate: '2023-12-20',
+        total: 480,
+        paid: 480,
+      },
+      {
+        id: 'ORD-0881',
+        type: 'عباءة فاخرة',
+        status: 'مسلم',
+        orderDate: '2023-10-18',
+        deliveryDate: '2023-10-30',
+        total: 520,
+        paid: 520,
+      },
+    ],
+    notes: 'يفضل الأقمشة الفاخرة ذات الألوان الهادئة.',
+  },
+  {
+    id: 2,
+    name: 'صالح علي الأحمد',
+    phone: '07807654321',
+    address: 'البصرة، حي العشار',
+    totalSpent: 680,
+    lastOrder: '2024-01-14',
+    label: 'وفي',
+    measurements: {
+      height: 138,
+      shoulder: 46,
+      waist: 40,
+      chest: 104,
+    },
+    orders: [
+      {
+        id: 'ORD-1101',
+        type: 'دشداشة إماراتية',
+        status: 'قيد التنفيذ',
+        orderDate: '2024-01-14',
+        deliveryDate: '2024-01-24',
+        total: 220,
+        paid: 100,
+      },
+      {
+        id: 'ORD-1042',
+        type: 'بدلة عصرية',
+        status: 'جاهز',
+        orderDate: '2023-12-22',
+        deliveryDate: '2024-01-02',
+        total: 210,
+        paid: 210,
+      },
+      {
+        id: 'ORD-0975',
+        type: 'دشداشة صيفية',
+        status: 'مسلم',
+        orderDate: '2023-08-18',
+        deliveryDate: '2023-08-30',
+        total: 250,
+        paid: 250,
+      },
+    ],
+  },
+  {
+    id: 3,
+    name: 'محمد خالد ',
+    phone: '07909876543',
+    address: 'الموصل، حي الزراعة',
+    totalSpent: 420,
+    lastOrder: '2024-01-10',
+    label: 'منتظم',
+    measurements: {
+      height: 140,
+      shoulder: 45,
+      waist: 38,
+      chest: 100,
+    },
+    orders: [
+      {
+        id: 'ORD-1200',
+        type: 'دشداشة كلاسيكية',
+        status: 'قيد التنفيذ',
+        orderDate: '2024-01-10',
+        deliveryDate: '2024-01-22',
+        total: 180,
+        paid: 50,
+      },
+      {
+        id: 'ORD-1133',
+        type: 'قميص رسمي',
+        status: 'مسلم',
+        orderDate: '2023-11-28',
+        deliveryDate: '2023-12-08',
+        total: 120,
+        paid: 120,
+      },
+      {
+        id: 'ORD-1008',
+        type: 'سروال رسمي',
+        status: 'مسلم',
+        orderDate: '2023-06-12',
+        deliveryDate: '2023-06-25',
+        total: 120,
+        paid: 120,
+      },
+    ],
+  },
+  {
+    id: 4,
+    name: 'علي حسن ',
+    phone: '07512345678',
+    address: 'أربيل، حي أنكاوا',
+    totalSpent: 150,
+    lastOrder: '2024-01-12',
+    label: 'جديد',
+    measurements: {
+      height: 144,
+      shoulder: 47,
+      waist: 42,
+      chest: 108,
+    },
+    orders: [
+      {
+        id: 'ORD-1302',
+        type: 'دشداشة شبابية',
+        status: 'جديد',
+        orderDate: '2024-01-12',
+        deliveryDate: '2024-01-28',
+        total: 150,
+        paid: 50,
+      },
+    ],
+  },
+  {
+    id: 5,
+    name: 'عبدالله أحمد ',
+    phone: '07605678901',
+    address: 'النجف، حي الاسرة',
+    totalSpent: 890,
+    lastOrder: '2024-01-08',
+    label: 'وفي',
+    measurements: {
+      height: 139,
+      shoulder: 44,
+      waist: 39,
+      chest: 102,
+    },
+    orders: [
+      {
+        id: 'ORD-1155',
+        type: 'قميص عملي',
+        status: 'مسلم',
+        orderDate: '2023-09-15',
+        deliveryDate: '2023-09-28',
+        total: 200,
+        paid: 200,
+      },
+      {
+        id: 'ORD-0902',
+        type: 'دشداشة رسمية',
+        status: 'مسلم',
+        orderDate: '2023-11-30',
+        deliveryDate: '2023-12-10',
+        total: 230,
+        paid: 230,
+      },
+      {
+        id: 'ORD-1011',
+        type: 'جاكيت شتوي',
+        status: 'مسلم',
+        orderDate: '2023-12-20',
+        deliveryDate: '2024-01-05',
+        total: 260,
+        paid: 260,
+      },
+      {
+        id: 'ORD-1077',
+        type: 'دشداشة بخيوط تطريز',
+        status: 'جاهز',
+        orderDate: '2024-01-08',
+        deliveryDate: '2024-01-21',
+        total: 200,
+        paid: 120,
+      },
+    ],
+    notes: 'يحب التفاصيل المطرزة حول الياقة والأكمام.',
+  },
+];
 
 export default function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [currentPage, setCurrentPage] = useState('dashboard');
+  const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
 
   const handleLogin = () => {
     setIsLoggedIn(true);
     setCurrentPage('dashboard');
+    setSelectedCustomer(null);
   };
 
   const handleLogout = () => {
     setIsLoggedIn(false);
     setCurrentPage('dashboard');
+    setSelectedCustomer(null);
   };
 
   const handleNavigate = (page: string) => {
     setCurrentPage(page);
+    if (page !== 'customerDetails') {
+      setSelectedCustomer(null);
+    }
+  };
+
+  const handleCustomerSelect = (customer: Customer) => {
+    setSelectedCustomer(customer);
+    setCurrentPage('customerDetails');
   };
 
   const renderCurrentPage = () => {
@@ -36,7 +265,27 @@ export default function App() {
       case 'invoices':
         return <InvoicesPage />;
       case 'customers':
-        return <CustomersPage />;
+        return (
+          <CustomersPage
+            customers={customersData}
+            onCustomerSelect={handleCustomerSelect}
+          />
+        );
+      case 'customerDetails':
+        return selectedCustomer ? (
+          <CustomerDetailsPage
+            customer={selectedCustomer}
+            onBack={() => {
+              setSelectedCustomer(null);
+              setCurrentPage('customers');
+            }}
+          />
+        ) : (
+          <CustomersPage
+            customers={customersData}
+            onCustomerSelect={handleCustomerSelect}
+          />
+        );
       case 'reports':
         return <ReportsPage />;
       case 'financial':

--- a/ازياء قرطبة/src/components/CustomerDetailsPage.tsx
+++ b/ازياء قرطبة/src/components/CustomerDetailsPage.tsx
@@ -1,0 +1,386 @@
+import React, { useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Button } from './ui/button';
+import { Badge } from './ui/badge';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './ui/dialog';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { Textarea } from './ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import { Customer } from '../types/customer';
+import {
+  Phone,
+  MapPin,
+  Calendar,
+  CreditCard,
+  ArrowRight,
+  ClipboardList,
+  Plus,
+  Star,
+} from 'lucide-react';
+
+interface CustomerDetailsPageProps {
+  customer: Customer;
+  onBack: () => void;
+}
+
+const getLabelColor = (label: string) => {
+  switch (label) {
+    case 'جديد':
+      return 'bg-blue-100 text-blue-800';
+    case 'منتظم':
+      return 'bg-green-100 text-green-800';
+    case 'وفي':
+      return 'bg-purple-100 text-purple-800';
+    case 'ذهبي':
+      return 'bg-yellow-100 text-yellow-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+};
+
+const getLabelIcon = (label: string) => {
+  switch (label) {
+    case 'ذهبي':
+      return <Star className="w-3 h-3" />;
+    default:
+      return null;
+  }
+};
+
+const getStatusBadgeColor = (status: string) => {
+  switch (status) {
+    case 'جديد':
+      return 'bg-blue-100 text-blue-800';
+    case 'قيد التنفيذ':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'جاهز':
+      return 'bg-green-100 text-green-800';
+    case 'مسلم':
+      return 'bg-gray-100 text-gray-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+};
+
+export function CustomerDetailsPage({ customer, onBack }: CustomerDetailsPageProps) {
+  const [isNewOrderOpen, setIsNewOrderOpen] = useState(false);
+
+  const sortedOrders = useMemo(
+    () =>
+      [...customer.orders].sort(
+        (a, b) => new Date(b.orderDate).getTime() - new Date(a.orderDate).getTime()
+      ),
+    [customer]
+  );
+
+  const handleNewOrderSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsNewOrderOpen(false);
+  };
+
+  const measurementItems = [
+    { label: 'الطول', value: `${customer.measurements.height} سم` },
+    { label: 'الكتف', value: `${customer.measurements.shoulder} سم` },
+    { label: 'الخصر', value: `${customer.measurements.waist} سم` },
+    { label: 'الصدر', value: `${customer.measurements.chest} سم` },
+  ];
+
+  return (
+    <div className="container mx-auto p-4 space-y-6">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="outline"
+              onClick={onBack}
+              className="border-[#C69A72] text-[#13312A] hover:bg-[#C69A72] touch-target"
+            >
+              <ArrowRight className="w-4 h-4 ml-2" />
+              <span className="arabic-text">عودة إلى الزبائن</span>
+            </Button>
+            <h1 className="text-2xl text-[#13312A] arabic-text">تفاصيل الزبون</h1>
+          </div>
+          <Button
+            onClick={() => setIsNewOrderOpen(true)}
+            className="bg-[#155446] hover:bg-[#13312A] text-[#F6E9CA] touch-target"
+          >
+            <Plus className="w-4 h-4 ml-2" />
+            <span className="arabic-text">إضافة طلب جديد</span>
+          </Button>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-lg text-[#13312A] arabic-text">{customer.name}</span>
+          <Badge className={`${getLabelColor(customer.label)} flex items-center gap-1`}>
+            {getLabelIcon(customer.label)}
+            {customer.label}
+          </Badge>
+        </div>
+      </div>
+
+      <Card className="bg-white border-[#C69A72]">
+        <CardHeader>
+          <CardTitle className="text-[#13312A] arabic-text text-lg">البيانات الأساسية</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-[#155446]">
+            <div className="flex items-center gap-2">
+              <Phone className="w-4 h-4" />
+              <span>{customer.phone}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Calendar className="w-4 h-4" />
+              <span className="arabic-text">آخر طلب: {customer.lastOrder}</span>
+            </div>
+            <div className="flex items-center gap-2 md:col-span-2">
+              <MapPin className="w-4 h-4" />
+              <span className="arabic-text">{customer.address}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <CreditCard className="w-4 h-4" />
+              <span className="arabic-text">إجمالي المصروف: {customer.totalSpent} دينار عراقي</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <ClipboardList className="w-4 h-4" />
+              <span className="arabic-text">عدد الطلبات: {customer.orders.length}</span>
+            </div>
+          </div>
+          {customer.notes && (
+            <div className="bg-[#FDF9F1] border border-dashed border-[#C69A72] rounded-lg p-4 text-sm text-[#13312A] arabic-text">
+              <p className="font-medium mb-2">ملاحظات خاصة</p>
+              <p>{customer.notes}</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="bg-white border-[#C69A72]">
+        <CardHeader>
+          <CardTitle className="text-[#13312A] arabic-text text-lg">قياسات الزبون</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {measurementItems.map((item) => (
+              <div
+                key={item.label}
+                className="bg-[#FDF9F1] border border-[#C69A72] rounded-lg p-4 text-center"
+              >
+                <p className="text-sm text-[#155446] arabic-text">{item.label}</p>
+                <p className="text-xl text-[#13312A]">{item.value}</p>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="bg-white border-[#C69A72]">
+        <CardHeader>
+          <CardTitle className="text-[#13312A] arabic-text text-lg">سجل الطلبات</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {sortedOrders.length > 0 ? (
+            sortedOrders.map((order) => {
+              const remaining = order.total - order.paid;
+              return (
+                <div
+                  key={order.id}
+                  className="bg-[#FDF9F1] border border-[#C69A72] rounded-lg p-4"
+                >
+                  <div className="flex flex-col md:flex-row md:items-start justify-between gap-4">
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-center gap-3 flex-wrap">
+                        <span className="text-lg text-[#13312A] arabic-text">{order.type}</span>
+                        <Badge className={getStatusBadgeColor(order.status)}>{order.status}</Badge>
+                      </div>
+                      <span className="text-sm text-[#155446] arabic-text">رقم الطلب: {order.id}</span>
+                    </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 text-sm text-[#155446] arabic-text">
+                      <div className="flex items-center gap-2">
+                        <Calendar className="w-4 h-4" />
+                        <span>تاريخ الطلب: {order.orderDate}</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Calendar className="w-4 h-4" />
+                        <span>تاريخ التسليم: {order.deliveryDate}</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <CreditCard className="w-4 h-4" />
+                        <span>التكلفة: {order.total} د.ع</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <CreditCard className="w-4 h-4" />
+                        <span>المتبقي: {remaining} د.ع</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <p className="text-sm text-[#155446] arabic-text">
+              لا توجد طلبات مسجلة لهذا الزبون بعد.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={isNewOrderOpen} onOpenChange={setIsNewOrderOpen}>
+        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto bg-[#F6E9CA] border-[#C69A72]">
+          <DialogHeader>
+            <DialogTitle className="text-[#13312A] arabic-text">
+              طلب جديد للزبون {customer.name}
+            </DialogTitle>
+            <DialogDescription className="text-[#155446] arabic-text">
+              تم تعبئة بيانات الزبون وقياساته بشكل تلقائي ويمكنك تعديلها قبل الحفظ
+            </DialogDescription>
+          </DialogHeader>
+
+          <form className="space-y-6" onSubmit={handleNewOrderSubmit}>
+            <Card className="bg-white border-[#C69A72]">
+              <CardHeader>
+                <CardTitle className="text-[#13312A] arabic-text text-lg">بيانات الزبون</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label className="text-[#13312A] arabic-text">اسم الزبون</Label>
+                  <Input
+                    defaultValue={customer.name}
+                    className="bg-white border-[#C69A72] text-right"
+                  />
+                </div>
+                <div>
+                  <Label className="text-[#13312A] arabic-text">رقم الهاتف</Label>
+                  <Input
+                    defaultValue={customer.phone}
+                    className="bg-white border-[#C69A72] text-right"
+                  />
+                </div>
+                <div className="md:col-span-2">
+                  <Label className="text-[#13312A] arabic-text">العنوان</Label>
+                  <Input
+                    defaultValue={customer.address}
+                    className="bg-white border-[#C69A72] text-right"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-white border-[#C69A72]">
+              <CardHeader>
+                <CardTitle className="text-[#13312A] arabic-text text-lg">القياسات</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div>
+                  <Label className="text-[#13312A] arabic-text">الطول</Label>
+                  <Input
+                    type="number"
+                    defaultValue={customer.measurements.height}
+                    className="bg-white border-[#C69A72] text-right"
+                  />
+                </div>
+                <div>
+                  <Label className="text-[#13312A] arabic-text">الكتف</Label>
+                  <Input
+                    type="number"
+                    defaultValue={customer.measurements.shoulder}
+                    className="bg-white border-[#C69A72] text-right"
+                  />
+                </div>
+                <div>
+                  <Label className="text-[#13312A] arabic-text">الخصر</Label>
+                  <Input
+                    type="number"
+                    defaultValue={customer.measurements.waist}
+                    className="bg-white border-[#C69A72] text-right"
+                  />
+                </div>
+                <div>
+                  <Label className="text-[#13312A] arabic-text">الصدر</Label>
+                  <Input
+                    type="number"
+                    defaultValue={customer.measurements.chest}
+                    className="bg-white border-[#C69A72] text-right"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-white border-[#C69A72]">
+              <CardHeader>
+                <CardTitle className="text-[#13312A] arabic-text text-lg">تفاصيل الطلب</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label className="text-[#13312A] arabic-text">نوع التصميم</Label>
+                  <Select>
+                    <SelectTrigger className="bg-white border-[#C69A72] text-right">
+                      <SelectValue placeholder="اختر نوع التصميم" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="kandora">دشداشة</SelectItem>
+                      <SelectItem value="suit">بدلة رسمية</SelectItem>
+                      <SelectItem value="abaya">عباءة</SelectItem>
+                      <SelectItem value="shirt">قميص</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <Label className="text-[#13312A] arabic-text">نوع القماش</Label>
+                  <Select>
+                    <SelectTrigger className="bg-white border-[#C69A72] text-right">
+                      <SelectValue placeholder="اختر نوع القماش" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="cotton">قطن</SelectItem>
+                      <SelectItem value="silk">حرير</SelectItem>
+                      <SelectItem value="linen">كتان</SelectItem>
+                      <SelectItem value="wool">صوف</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <Label className="text-[#13312A] arabic-text">تاريخ التسليم</Label>
+                  <Input type="date" className="bg-white border-[#C69A72] text-right" />
+                </div>
+                <div>
+                  <Label className="text-[#13312A] arabic-text">التكلفة المتوقعة</Label>
+                  <Input type="number" placeholder="0" className="bg-white border-[#C69A72] text-right" />
+                </div>
+                <div>
+                  <Label className="text-[#13312A] arabic-text">الدفعة المقدمة</Label>
+                  <Input type="number" placeholder="0" className="bg-white border-[#C69A72] text-right" />
+                </div>
+                <div className="md:col-span-2">
+                  <Label className="text-[#13312A] arabic-text">ملاحظات إضافية</Label>
+                  <Textarea
+                    rows={3}
+                    placeholder="اكتب أي تفاصيل إضافية حول الطلب"
+                    className="bg-white border-[#C69A72] text-right"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            <div className="flex justify-end gap-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsNewOrderOpen(false)}
+                className="border-[#C69A72] text-[#13312A] hover:bg-[#C69A72]"
+              >
+                إلغاء
+              </Button>
+              <Button
+                type="submit"
+                className="bg-[#155446] hover:bg-[#13312A] text-[#F6E9CA]"
+              >
+                حفظ الطلب
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/ازياء قرطبة/src/components/CustomersPage.tsx
+++ b/ازياء قرطبة/src/components/CustomersPage.tsx
@@ -4,12 +4,11 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { Badge } from './ui/badge';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription } from './ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from './ui/dialog';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
-import { 
-  Plus, 
-  Search, 
-  Filter, 
+import {
+  Plus,
+  Search,
   Edit,
   Phone,
   MapPin,
@@ -17,64 +16,17 @@ import {
   CreditCard,
   Star
 } from 'lucide-react';
+import { Customer } from '../types/customer';
 
-export function CustomersPage() {
+interface CustomersPageProps {
+  customers: Customer[];
+  onCustomerSelect: (customer: Customer) => void;
+}
+
+export function CustomersPage({ customers, onCustomerSelect }: CustomersPageProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterLabel, setFilterLabel] = useState('all');
   const [isNewCustomerOpen, setIsNewCustomerOpen] = useState(false);
-
-  const customers = [
-    {
-      id: 1,
-      name: 'أحمد محمد العراقي',
-      phone: '07701234567',
-      address: 'بغداد، منطقة الكرخ',
-      totalSpent: 1250,
-      lastOrder: '2024-01-15',
-      label: 'ذهبي',
-      ordersCount: 8
-    },
-    {
-      id: 2,
-      name: 'صالح علي الأحمد',
-      phone: '07807654321',
-      address: 'البصرة، حي العشار',
-      totalSpent: 680,
-      lastOrder: '2024-01-14',
-      label: 'وفي',
-      ordersCount: 4
-    },
-    {
-      id: 3,
-      name: 'محمد خالد ',
-      phone: '07909876543',
-      address: 'الموصل، حي الزراعة',
-      totalSpent: 420,
-      lastOrder: '2024-01-10',
-      label: 'منتظم',
-      ordersCount: 2
-    },
-    {
-      id: 4,
-      name: 'علي حسن ',
-      phone: '07512345678',
-      address: 'أربيل، حي أنكاوا',
-      totalSpent: 150,
-      lastOrder: '2024-01-12',
-      label: 'جديد',
-      ordersCount: 1
-    },
-    {
-      id: 5,
-      name: 'عبدالله أحمد ',
-      phone: '07605678901',
-      address: 'النجف، حي الاسرة',
-      totalSpent: 890,
-      lastOrder: '2024-01-08',
-      label: 'وفي',
-      ordersCount: 5
-    }
-  ];
 
   const getLabelColor = (label: string) => {
     switch (label) {
@@ -224,54 +176,78 @@ export function CustomersPage() {
 
       {/* Customers List */}
       <div className="grid gap-4">
-        {filteredCustomers.map((customer) => (
-          <Card key={customer.id} className="bg-white border-[#C69A72] hover:shadow-lg transition-shadow">
-            <CardContent className="p-4">
-              <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-                <div className="flex-1">
-                  <div className="flex items-center gap-3 mb-3">
-                    <h3 className="text-lg text-[#13312A] arabic-text">{customer.name}</h3>
-                    <Badge className={`${getLabelColor(customer.label)} flex items-center gap-1`}>
-                      {getLabelIcon(customer.label)}
-                      {customer.label}
-                    </Badge>
+        {filteredCustomers.map((customer) => {
+          const ordersCount = customer.orders.length;
+          return (
+            <Card
+              key={customer.id}
+              onClick={() => onCustomerSelect(customer)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  onCustomerSelect(customer);
+                }
+              }}
+              tabIndex={0}
+              role="button"
+              aria-label={`عرض تفاصيل ${customer.name}`}
+              className="bg-white border-[#C69A72] hover:shadow-lg transition-shadow cursor-pointer focus:outline-none focus:ring-2 focus:ring-[#C69A72]"
+            >
+              <CardContent className="p-4">
+                <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-3 mb-3">
+                      <h3 className="text-lg text-[#13312A] arabic-text">{customer.name}</h3>
+                      <Badge className={`${getLabelColor(customer.label)} flex items-center gap-1`}>
+                        {getLabelIcon(customer.label)}
+                        {customer.label}
+                      </Badge>
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 text-sm">
+                      <div className="flex items-center gap-2 text-[#155446]">
+                        <Phone className="w-4 h-4" />
+                        <span>{customer.phone}</span>
+                      </div>
+                      <div className="flex items-center gap-2 text-[#155446]">
+                        <MapPin className="w-4 h-4" />
+                        <span className="arabic-text">{customer.address}</span>
+                      </div>
+                      <div className="flex items-center gap-2 text-[#155446]">
+                        <CreditCard className="w-4 h-4" />
+                        <span className="arabic-text">{customer.totalSpent} دينار عراقي</span>
+                      </div>
+                      <div className="flex items-center gap-2 text-[#155446]">
+                        <Calendar className="w-4 h-4" />
+                        <span className="arabic-text">آخر طلب: {customer.lastOrder}</span>
+                      </div>
+                    </div>
                   </div>
-                  
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 text-sm">
-                    <div className="flex items-center gap-2 text-[#155446]">
-                      <Phone className="w-4 h-4" />
-                      <span>{customer.phone}</span>
+
+                  <div className="flex flex-col md:flex-row items-start md:items-center gap-4">
+                    <div className="text-center">
+                      <p className="text-2xl text-[#13312A]">{ordersCount}</p>
+                      <p className="text-sm text-[#155446] arabic-text">طلب</p>
                     </div>
-                    <div className="flex items-center gap-2 text-[#155446]">
-                      <MapPin className="w-4 h-4" />
-                      <span className="arabic-text">{customer.address}</span>
-                    </div>
-                    <div className="flex items-center gap-2 text-[#155446]">
-                      <CreditCard className="w-4 h-4" />
-                      <span className="arabic-text">{customer.totalSpent} دينار عراقي</span>
-                    </div>
-                    <div className="flex items-center gap-2 text-[#155446]">
-                      <Calendar className="w-4 h-4" />
-                      <span className="arabic-text">آخر طلب: {customer.lastOrder}</span>
-                    </div>
+
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="border-[#C69A72] text-[#13312A] hover:bg-[#C69A72] touch-target"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        event.preventDefault();
+                      }}
+                    >
+                      <Edit className="w-4 h-4 ml-1" />
+                      <span className="arabic-text">تعديل</span>
+                    </Button>
                   </div>
                 </div>
-                
-                <div className="flex flex-col md:flex-row items-start md:items-center gap-4">
-                  <div className="text-center">
-                    <p className="text-2xl text-[#13312A]">{customer.ordersCount}</p>
-                    <p className="text-sm text-[#155446] arabic-text">طلب</p>
-                  </div>
-                  
-                  <Button size="sm" variant="outline" className="border-[#C69A72] text-[#13312A] hover:bg-[#C69A72] touch-target">
-                    <Edit className="w-4 h-4 ml-1" />
-                    <span className="arabic-text">تعديل</span>
-                  </Button>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
 
       <NewCustomerDialog />

--- a/ازياء قرطبة/src/components/CustomersPage.tsx
+++ b/ازياء قرطبة/src/components/CustomersPage.tsx
@@ -274,33 +274,6 @@ export function CustomersPage() {
         ))}
       </div>
 
-      {/* Summary */}
-      <Card className="bg-white border-[#C69A72]">
-        <CardHeader>
-          <CardTitle className="text-[#13312A] arabic-text">ملخص الزبائن</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="text-center">
-              <p className="text-3xl text-[#13312A] mb-2">{customers.length}</p>
-              <p className="text-[#155446] arabic-text">إجمالي الزبائن</p>
-            </div>
-            <div className="text-center">
-              <p className="text-3xl text-[#13312A] mb-2">
-                {customers.reduce((sum, customer) => sum + customer.totalSpent, 0)} دينار عراقي
-              </p>
-              <p className="text-[#155446] arabic-text">إجمالي المبيعات</p>
-            </div>
-            <div className="text-center">
-              <p className="text-3xl text-[#13312A] mb-2">
-                {(customers.reduce((sum, customer) => sum + customer.totalSpent, 0) / customers.length).toFixed(0)} دينار عراقي
-              </p>
-              <p className="text-[#155446] arabic-text">متوسط الإنفاق</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
       <NewCustomerDialog />
     </div>
   );

--- a/ازياء قرطبة/src/components/Dashboard.tsx
+++ b/ازياء قرطبة/src/components/Dashboard.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
-import { 
-  Scissors, 
-  Ruler, 
-  FileText, 
-  Receipt, 
-  Users, 
-  TrendingUp,
+import {
+  Scissors,
+  FileText,
+  Receipt,
+  Users,
   Calendar,
-  Bell,
-  Package
+  Bell
 } from 'lucide-react';
 
 interface DashboardProps {
@@ -25,12 +22,6 @@ export function Dashboard({ onNavigate }: DashboardProps) {
     { label: 'زبون جديد', icon: Users, action: () => onNavigate('customers'), color: 'bg-[#13312A]' },
   ];
   
-  const stats = [
-    { label: 'الطلبات الجديدة', value: '12', icon: FileText, color: 'bg-[#155446]' },
-    { label: 'الفواتير المعلقة', value: '8', icon: Receipt, color: 'bg-[#C69A72]' },
-    { label: 'إجمالي الزبائن', value: '156', icon: Users, color: 'bg-[#13312A]' },
-    { label: 'المبيعات اليوم', value: '2,450 دينار عراقي', icon: TrendingUp, color: 'bg-[#155446]' },
-  ];
 
   
   const upcomingTasks = [
@@ -44,33 +35,12 @@ export function Dashboard({ onNavigate }: DashboardProps) {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl text-[#13312A] arabic-text mb-2">أهلاً وسهلاً</h1>
-          <p className="text-[#155446] arabic-text">نظرة عامة على المبيعات اليوم</p>
+          <p className="text-[#155446] arabic-text">نظرة عامة على العمل اليوم</p>
         </div>
         <Button className="bg-[#155446] hover:bg-[#13312A] text-[#F6E9CA] touch-target">
           <Bell className="w-4 h-4 ml-2" />
           <span className="arabic-text">الإشعارات</span>
         </Button>
-      </div>
-
-      {/* Stats Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        {stats.map((stat, index) => {
-          const Icon = stat.icon;
-          return (
-            
-            <Card key={index} className="bg-white border-[#C69A72] hover:shadow-lg transition-shadow">
-              <CardContent className="flex items-center p-4">
-                <div className={`w-12 h-12 ${stat.color} rounded-lg flex items-center justify-center ml-4`}>
-                  <Icon className="w-6 h-6 text-[#F6E9CA]" />
-                </div>
-                <div>
-                  <p className="text-2xl text-[#13312A] mb-1">{stat.value}</p>
-                  <p className="text-sm text-[#155446] arabic-text">{stat.label}</p>
-                </div>
-              </CardContent>
-            </Card>
-          );
-        })}
       </div>
 
       {/* Quick Actions */}

--- a/ازياء قرطبة/src/components/FinancialPage.tsx
+++ b/ازياء قرطبة/src/components/FinancialPage.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Card, CardContent } from './ui/card';
+import { TrendingUp, FileText, DollarSign, Users } from 'lucide-react';
+
+export function FinancialPage() {
+  const stats = [
+    { label: 'إجمالي المبيعات', value: '15,750 دينار عراقي', icon: TrendingUp, color: 'bg-[#155446]' },
+    { label: 'طلبات اليوم', value: '12', icon: FileText, color: 'bg-[#C69A72]' },
+    { label: 'الأرباح', value: '1,200 دينار عراقي', icon: DollarSign, color: 'bg-[#13312A]' },
+    { label: 'عدد الزبائن', value: '156', icon: Users, color: 'bg-[#155446]' }
+  ];
+
+  return (
+    <div className="container mx-auto p-4 space-y-6">
+      <h1 className="text-2xl text-center text-[#13312A] arabic-text">المالية</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {stats.map((stat, index) => {
+          const Icon = stat.icon;
+          return (
+            <Card key={index} className="bg-white border-[#C69A72]">
+              <CardContent className="flex items-center p-4">
+                <div className={`w-12 h-12 ${stat.color} rounded-lg flex items-center justify-center ml-4`}>
+                  <Icon className="w-6 h-6 text-[#F6E9CA]" />
+                </div>
+                <div>
+                  <p className="text-2xl text-[#13312A] mb-1">{stat.value}</p>
+                  <p className="text-sm text-[#155446] arabic-text">{stat.label}</p>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ازياء قرطبة/src/components/InvoicesPage.tsx
+++ b/ازياء قرطبة/src/components/InvoicesPage.tsx
@@ -288,31 +288,6 @@ export function InvoicesPage() {
         ))}
       </div>
 
-      {/* Summary Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card className="bg-white border-[#C69A72]">
-          <CardContent className="p-4 text-center">
-            <p className="text-2xl text-[#13312A] mb-1">{invoices.length}</p>
-            <p className="text-[#155446] arabic-text">إجمالي الفواتير</p>
-          </CardContent>
-        </Card>
-        <Card className="bg-white border-[#C69A72]">
-          <CardContent className="p-4 text-center">
-            <p className="text-2xl text-[#13312A] mb-1">
-              {invoices.reduce((sum, inv) => sum + inv.total, 0)} دينار عراقي
-            </p>
-            <p className="text-[#155446] arabic-text">إجمالي المبيعات</p>
-          </CardContent>
-        </Card>
-        <Card className="bg-white border-[#C69A72]">
-          <CardContent className="p-4 text-center">
-            <p className="text-2xl text-[#13312A] mb-1">
-              {invoices.filter(inv => inv.status === 'معلق').length}
-            </p>
-            <p className="text-[#155446] arabic-text">فواتير معلقة</p>
-          </CardContent>
-        </Card>
-      </div>
     </div>
   );
 }

--- a/ازياء قرطبة/src/components/Layout.tsx
+++ b/ازياء قرطبة/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Home, FileText, Receipt, Users, Menu, Settings, User, LogOut } from 'lucide-react';
+import { Home, FileText, Receipt, Users, Menu, Settings, User, LogOut, DollarSign } from 'lucide-react';
 import { Button } from './ui/button';
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from './ui/sheet';
 
@@ -17,6 +17,7 @@ export function Layout({ children, currentPage, onNavigate, isLoggedIn, onLogout
     { id: 'orders', label: 'الطلبات', icon: FileText },
     { id: 'invoices', label: 'الفواتير', icon: Receipt },
     { id: 'customers', label: 'الزبائن', icon: Users },
+    { id: 'financial', label: 'المالية', icon: DollarSign },
   ];
 
   const MobileNavigation = () => (

--- a/ازياء قرطبة/src/components/Layout.tsx
+++ b/ازياء قرطبة/src/components/Layout.tsx
@@ -19,6 +19,7 @@ export function Layout({ children, currentPage, onNavigate, isLoggedIn, onLogout
     { id: 'customers', label: 'الزبائن', icon: Users },
     { id: 'financial', label: 'المالية', icon: DollarSign },
   ];
+  const activePage = currentPage === 'customerDetails' ? 'customers' : currentPage;
 
   const MobileNavigation = () => (
     <div className="fixed bottom-0 left-0 right-0 bg-[#13312A] border-t border-[#155446] z-50 md:hidden">
@@ -32,8 +33,8 @@ export function Layout({ children, currentPage, onNavigate, isLoggedIn, onLogout
               size="sm"
               onClick={() => onNavigate(item.id)}
               className={`flex flex-col items-center gap-1 p-2 touch-target ${
-                currentPage === item.id 
-                  ? 'text-[#F6E9CA] bg-[#155446]' 
+                activePage === item.id
+                  ? 'text-[#F6E9CA] bg-[#155446]'
                   : 'text-[#C69A72] hover:text-[#F6E9CA] hover:bg-[#155446]'
               }`}
             >
@@ -108,8 +109,8 @@ export function Layout({ children, currentPage, onNavigate, isLoggedIn, onLogout
                     variant="ghost"
                     onClick={() => onNavigate(item.id)}
                     className={`flex items-center gap-2 px-4 py-2 touch-target ${
-                      currentPage === item.id 
-                        ? 'text-[#F6E9CA] bg-[#155446]' 
+                      activePage === item.id
+                        ? 'text-[#F6E9CA] bg-[#155446]'
                         : 'text-[#C69A72] hover:text-[#F6E9CA] hover:bg-[#155446]'
                     }`}
                   >
@@ -121,11 +122,11 @@ export function Layout({ children, currentPage, onNavigate, isLoggedIn, onLogout
               <Button
                 variant="ghost"
                 onClick={() => onNavigate('reports')}
-                className={`flex items-center gap-2 px-4 py-2 touch-target ${
-                  currentPage === 'reports' 
-                    ? 'text-[#F6E9CA] bg-[#155446]' 
-                    : 'text-[#C69A72] hover:text-[#F6E9CA] hover:bg-[#155446]'
-                }`}
+              className={`flex items-center gap-2 px-4 py-2 touch-target ${
+                activePage === 'reports'
+                  ? 'text-[#F6E9CA] bg-[#155446]'
+                  : 'text-[#C69A72] hover:text-[#F6E9CA] hover:bg-[#155446]'
+              }`}
               >
                 <FileText size={18} />
                 <span className="arabic-text">التقارير</span>

--- a/ازياء قرطبة/src/components/ReportsPage.tsx
+++ b/ازياء قرطبة/src/components/ReportsPage.tsx
@@ -97,33 +97,6 @@ export function ReportsPage() {
         </div>
       </div>
 
-      {/* Current Stats Preview */}
-      <Card className="bg-white border-[#C69A72]">
-        <CardHeader>
-          <CardTitle className="text-[#13312A] arabic-text text-center">نظرة سريعة على الإحصائيات الحالية</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <div className="text-center p-4 bg-[#F6E9CA] rounded-lg border border-[#C69A72]">
-              <p className="text-2xl text-[#13312A] mb-2">28</p>
-              <p className="text-[#155446] arabic-text">طلبات هذا الشهر</p>
-            </div>
-            <div className="text-center p-4 bg-[#F6E9CA] rounded-lg border border-[#C69A72]">
-              <p className="text-2xl text-[#13312A] mb-2">15,750 دينار</p>
-              <p className="text-[#155446] arabic-text">مبيعات الشهر</p>
-            </div>
-            <div className="text-center p-4 bg-[#F6E9CA] rounded-lg border border-[#C69A72]">
-              <p className="text-2xl text-[#13312A] mb-2">156</p>
-              <p className="text-[#155446] arabic-text">إجمالي الزبائن</p>
-            </div>
-            <div className="text-center p-4 bg-[#F6E9CA] rounded-lg border border-[#C69A72]">
-              <p className="text-2xl text-[#13312A] mb-2">92%</p>
-              <p className="text-[#155446] arabic-text">معدل الرضا</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
       {/* Progress Indicator */}
       <Card className="bg-white border-[#C69A72]">
         <CardContent className="p-6">

--- a/ازياء قرطبة/src/types/customer.ts
+++ b/ازياء قرطبة/src/types/customer.ts
@@ -1,0 +1,29 @@
+export interface CustomerMeasurements {
+  height: number;
+  shoulder: number;
+  waist: number;
+  chest: number;
+}
+
+export interface CustomerOrder {
+  id: string;
+  type: string;
+  status: string;
+  orderDate: string;
+  deliveryDate: string;
+  total: number;
+  paid: number;
+}
+
+export interface Customer {
+  id: number;
+  name: string;
+  phone: string;
+  address: string;
+  totalSpent: number;
+  lastOrder: string;
+  label: string;
+  measurements: CustomerMeasurements;
+  orders: CustomerOrder[];
+  notes?: string;
+}


### PR DESCRIPTION
## Summary
- add financial page with sales, orders, profit, and customer stats
- route financial page in app layout navigation
- remove financial summaries from other pages to centralize data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c828958c9c8328811c2bcb888b8ab1