### PR TITLE
Add printable exports for admin listings

### DIFF
--- a/ازياء قرطبة/src/components/ReportsPage.tsx
+++ b/ازياء قرطبة/src/components/ReportsPage.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
-import { 
-  BarChart, 
-  TrendingUp, 
+import {
+  BarChart,
+  TrendingUp,
   Calendar,
   Clock,
   Wrench,
-  Sparkles
+  Sparkles,
+  Printer
 } from 'lucide-react';
+import { openPrintWindow, formatPrintDateTime } from './print/PrintUtils';
 
 export function ReportsPage() {
   const upcomingFeatures = [
@@ -38,8 +40,135 @@ export function ReportsPage() {
     }
   ];
 
+  const progressPercent = 35;
+  const releaseWindow = 'الربع الثاني 2026';
+  const nearestLaunch = upcomingFeatures[0]?.estimatedDate ?? '—';
+  const finalLaunch = upcomingFeatures[upcomingFeatures.length - 1]?.estimatedDate ?? '—';
+
+  const handlePrintReports = () => {
+    const now = new Date();
+    const timelineBadgeStyle: React.CSSProperties = {
+      backgroundColor: 'rgba(21, 84, 70, 0.12)',
+      color: '#155446',
+      border: '1px solid rgba(21, 84, 70, 0.35)',
+    };
+    const planBadgeStyle: React.CSSProperties = {
+      backgroundColor: 'rgba(198, 154, 114, 0.2)',
+      color: '#13312A',
+      border: '1px solid rgba(198, 154, 114, 0.4)',
+    };
+    const nextSteps = [
+      'استكمال إعداد مصادر البيانات وربطها مع لوحة التحكم.',
+      'تطوير واجهات العرض البصري والتأكد من توافقها مع الهوية البصرية.',
+      'إطلاق مرحلة الاختبار الداخلي ثم إشعار المستخدمين بالإطلاق التجريبي.',
+    ];
+
+    openPrintWindow('ملخص تطوير التقارير', (
+      <>
+        <header className="print-header">
+          <h1 className="print-title">تقرير حالة تطوير نظام التقارير</h1>
+          <p className="print-subtitle">نظرة شاملة على مسار تطوير وحدات التقارير في منصة أزياء قرطبة</p>
+          <div className="print-meta">
+            <span>تاريخ الطباعة: {formatPrintDateTime(now)}</span>
+            <span>عدد الوحدات المخطط لها: {upcomingFeatures.length}</span>
+          </div>
+        </header>
+
+        <section className="print-section">
+          <h2 className="section-title">ملخص الإنجاز</h2>
+          <div className="metrics-grid">
+            <div className="metric-card accent">
+              <span className="metric-label">نسبة الإنجاز الحالية</span>
+              <span className="metric-value">{progressPercent}%</span>
+            </div>
+            <div className="metric-card">
+              <span className="metric-label">الإطلاق المتوقع</span>
+              <span className="metric-value">{releaseWindow}</span>
+            </div>
+            <div className="metric-card">
+              <span className="metric-label">أقرب مرحلة تنفيذ</span>
+              <span className="metric-value">{nearestLaunch}</span>
+            </div>
+            <div className="metric-card">
+              <span className="metric-label">آخر مرحلة مجدولة</span>
+              <span className="metric-value">{finalLaunch}</span>
+            </div>
+          </div>
+        </section>
+
+        <section className="print-section">
+          <h2 className="section-title">الميزات القادمة</h2>
+          <p className="section-description">تفاصيل وحدات التقارير التي سيتم إطلاقها تباعاً لدعم اتخاذ القرار في المركز.</p>
+          <div className="print-table-wrapper">
+            <table className="print-table">
+              <thead>
+                <tr>
+                  <th>التسلسل</th>
+                  <th>اسم التقرير</th>
+                  <th>الوصف المختصر</th>
+                  <th>الجدول الزمني</th>
+                </tr>
+              </thead>
+              <tbody>
+                {upcomingFeatures.map((feature, index) => (
+                  <tr key={feature.title}>
+                    <td>{index + 1}</td>
+                    <td>{feature.title}</td>
+                    <td>{feature.description}</td>
+                    <td>{feature.estimatedDate}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className="print-section">
+          <h2 className="section-title">خطط التنفيذ القادمة</h2>
+          <div className="detail-cards">
+            {upcomingFeatures.map((feature, index) => (
+              <article className="detail-card" key={`feature-${index}`}>
+                <div className="detail-card-header">
+                  <h3 className="detail-title">{feature.title}</h3>
+                  <span className="status-pill" style={timelineBadgeStyle}>{feature.estimatedDate}</span>
+                </div>
+                <div className="detail-grid">
+                  <div className="detail-item">
+                    <span className="item-label">الوصف</span>
+                    <span className="item-value">{feature.description}</span>
+                  </div>
+                </div>
+              </article>
+            ))}
+            <article className="detail-card" key="next-steps">
+              <div className="detail-card-header">
+                <h3 className="detail-title">الخطوات التالية</h3>
+                <span className="status-pill" style={planBadgeStyle}>خطة العمل</span>
+              </div>
+              <ul className="list bullet-list">
+                {nextSteps.map((step, index) => (
+                  <li key={`step-${index}`}>{step}</li>
+                ))}
+              </ul>
+            </article>
+          </div>
+        </section>
+      </>
+    ));
+  };
+
   return (
     <div className="container mx-auto p-4 space-y-6">
+      <div className="flex justify-end">
+        <Button
+          variant="outline"
+          onClick={handlePrintReports}
+          className="border-[#C69A72] text-[#13312A] hover:bg-[#C69A72] touch-target"
+        >
+          <Printer className="w-4 h-4 ml-2" />
+          <span className="arabic-text">طباعة الملخص</span>
+        </Button>
+      </div>
       {/* Header */}
       <div className="text-center space-y-4">
         <div className="flex justify-center">

--- a/ازياء قرطبة/src/components/print/PrintUtils.tsx
+++ b/ازياء قرطبة/src/components/print/PrintUtils.tsx
@@ -1,0 +1,365 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+export const brandPrintStyles = `
+  @page {
+    size: A4 portrait;
+    margin: 14mm;
+  }
+
+  body {
+    margin: 0;
+    background: #f4ede1;
+    font-family: 'Tajawal', 'Noto Kufi Arabic', sans-serif;
+    direction: rtl;
+    color: #13312A;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  .print-container {
+    width: 100%;
+    min-height: calc(100vh - 28mm);
+    background: linear-gradient(135deg, rgba(246, 233, 202, 0.96), rgba(255, 253, 247, 0.92));
+    border: 2px solid rgba(198, 154, 114, 0.65);
+    border-radius: 20px;
+    padding: 28px 32px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    box-shadow: 0 16px 42px rgba(19, 49, 42, 0.12);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .print-container::before {
+    content: '';
+    position: absolute;
+    inset: 12px;
+    border: 1px dashed rgba(198, 154, 114, 0.35);
+    border-radius: 16px;
+    pointer-events: none;
+  }
+
+  .print-inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+  }
+
+  .print-header {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-bottom: 16px;
+    border-bottom: 2px solid rgba(198, 154, 114, 0.5);
+  }
+
+  .print-title {
+    margin: 0;
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    color: #13312A;
+  }
+
+  .print-subtitle {
+    margin: 0;
+    font-size: 16px;
+    color: #155446;
+  }
+
+  .print-meta {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 12px 24px;
+    font-size: 13px;
+    color: #155446;
+  }
+
+  .print-section {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .section-title {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 700;
+    color: #13312A;
+  }
+
+  .section-description {
+    margin: 0;
+    font-size: 13px;
+    color: #155446;
+  }
+
+  .metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 14px;
+  }
+
+  .metric-card {
+    background: rgba(246, 233, 202, 0.9);
+    border: 1px solid rgba(198, 154, 114, 0.45);
+    border-radius: 14px;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-height: 96px;
+  }
+
+  .metric-card.accent {
+    background: linear-gradient(135deg, rgba(21, 84, 70, 0.92), rgba(19, 49, 42, 0.85));
+    border-color: rgba(21, 84, 70, 0.6);
+  }
+
+  .metric-label {
+    font-size: 13px;
+    color: #155446;
+  }
+
+  .metric-card.accent .metric-label {
+    color: rgba(246, 233, 202, 0.9);
+  }
+
+  .metric-value {
+    font-size: 19px;
+    font-weight: 700;
+    color: #13312A;
+  }
+
+  .metric-card.accent .metric-value {
+    color: #F6E9CA;
+  }
+
+  .print-table-wrapper {
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 0 0 1px rgba(198, 154, 114, 0.45);
+  }
+
+  table.print-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    direction: rtl;
+  }
+
+  table.print-table thead {
+    background: linear-gradient(135deg, rgba(19, 49, 42, 0.96), rgba(21, 84, 70, 0.92));
+    color: #F6E9CA;
+  }
+
+  table.print-table thead th {
+    padding: 10px 12px;
+    text-align: right;
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  table.print-table tbody tr {
+    background: rgba(255, 253, 247, 0.95);
+  }
+
+  table.print-table tbody tr:nth-child(even) {
+    background: rgba(246, 233, 202, 0.45);
+  }
+
+  table.print-table tbody td {
+    padding: 10px 12px;
+    border-bottom: 1px solid rgba(198, 154, 114, 0.3);
+    color: #155446;
+    vertical-align: top;
+  }
+
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 12px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    border: 1px solid transparent;
+    min-width: 72px;
+  }
+
+  .detail-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+  }
+
+  .detail-card {
+    background: rgba(255, 253, 247, 0.96);
+    border: 1px solid rgba(198, 154, 114, 0.5);
+    border-radius: 18px;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    box-shadow: 0 12px 24px rgba(19, 49, 42, 0.08);
+    page-break-inside: avoid;
+  }
+
+  .detail-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid rgba(198, 154, 114, 0.35);
+  }
+
+  .detail-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 700;
+    color: #13312A;
+  }
+
+  .detail-grid {
+    display: grid;
+    gap: 8px;
+  }
+
+  .detail-grid.two-column {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .detail-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: rgba(246, 233, 202, 0.35);
+    border: 1px solid rgba(198, 154, 114, 0.35);
+    border-radius: 12px;
+    padding: 8px 10px;
+  }
+
+  .item-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: #13312A;
+  }
+
+  .item-value {
+    font-size: 12px;
+    color: #155446;
+    line-height: 1.6;
+  }
+
+  .detail-subsection {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .subsection-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: #13312A;
+  }
+
+  .list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .list-item {
+    background: rgba(246, 233, 202, 0.3);
+    border: 1px solid rgba(198, 154, 114, 0.3);
+    border-radius: 12px;
+    padding: 8px 10px;
+    font-size: 12px;
+    color: #155446;
+    line-height: 1.6;
+  }
+
+  .bullet-list {
+    list-style: disc;
+    padding-right: 20px;
+    display: block;
+  }
+
+  .bullet-list li {
+    margin-bottom: 6px;
+  }
+
+  .print-footer {
+    margin-top: 12px;
+    text-align: center;
+    font-size: 12px;
+    color: #155446;
+  }
+
+  @media print {
+    body {
+      background: transparent;
+    }
+
+    .print-container {
+      box-shadow: none;
+    }
+  }
+`;
+
+export const formatPrintDateTime = (date: Date) =>
+  new Intl.DateTimeFormat('ar-IQ', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+  }).format(date);
+
+export const openPrintWindow = (title: string, content: React.ReactElement) => {
+  const printWindow = window.open('', '_blank', 'width=900,height=700');
+
+  if (!printWindow) {
+    return;
+  }
+
+  const markup = renderToStaticMarkup(content);
+
+  printWindow.document.write(`<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+  <head>
+    <meta charSet="utf-8" />
+    <title>${title}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+    <link href="https://fonts.googleapis.com/css2?family=Tajawal:wght@400;500;700&display=swap" rel="stylesheet" />
+    <style>${brandPrintStyles}</style>
+  </head>
+  <body>
+    <div class="print-container">
+      <div class="print-inner">${markup}</div>
+      <div class="print-footer">تم إنشاء هذا المستند من خلال نظام إدارة أزياء قرطبة</div>
+    </div>
+    <script>
+      window.onload = () => {
+        window.focus();
+        setTimeout(() => window.print(), 300);
+      };
+    <\/script>
+  </body>
+</html>`);
+
+  printWindow.document.close();
+  printWindow.focus();
+};


### PR DESCRIPTION
## Summary
- add a reusable print utility with brand-specific A4 styles
- wire print buttons into the invoices, customers, and reports admin views
- render detailed printable layouts for each page including metrics, tables, and cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c93e8dfbdc8328b68bb70b6faa0043