### PR TITLE
Tighten modal centering and overlay depth

### DIFF
--- a/ازياء قرطبة/src/components/ui/dialog.tsx
+++ b/ازياء قرطبة/src/components/ui/dialog.tsx
@@ -22,22 +22,30 @@ function useBodyScrollLock(isLocked: boolean) {
 }
 
 function Dialog({
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  const [open, setOpen] = React.useState(props.open ?? false);
-  
-  // Use body scroll lock when dialog is open
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(
+    defaultOpen ?? false,
+  );
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : uncontrolledOpen;
+
   useBodyScrollLock(open);
-  
+
   return (
-    <DialogPrimitive.Root 
-      data-slot="dialog" 
+    <DialogPrimitive.Root
+      data-slot="dialog"
       open={open}
-      onOpenChange={(newOpen) => {
-        setOpen(newOpen);
-        props.onOpenChange?.(newOpen);
+      onOpenChange={(nextOpen) => {
+        if (!isControlled) {
+          setUncontrolledOpen(nextOpen);
+        }
+        onOpenChange?.(nextOpen);
       }}
-      {...props} 
+      {...props}
     />
   );
 }
@@ -68,7 +76,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "fixed inset-0 z-[999] bg-slate-950/70 backdrop-blur data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className,
       )}
       {...props}
@@ -84,22 +92,26 @@ function DialogContent({
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
-      <DialogPrimitive.Content
-        data-slot="dialog-content"
-        className={cn(
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 min-h-[100dvh]",
-          className,
-        )}
-        {...props}
-      >
-        <div className="relative w-full sm:max-w-2xl bg-background rounded-t-2xl sm:rounded-2xl shadow-lg max-h-[100dvh] overflow-y-auto -webkit-overflow-scrolling-touch">
-          {children}
-          <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-            <XIcon />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
+      <div className="fixed inset-0 z-[1000] overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4 sm:p-6">
+          <DialogPrimitive.Content
+            data-slot="dialog-content"
+            className={cn(
+              "relative flex max-h-[calc(100dvh-3rem)] w-full max-w-[min(100vw-2rem,90rem)] flex-col overflow-hidden rounded-2xl border border-border/60 bg-background text-foreground shadow-[0_20px_70px_rgba(15,23,42,0.35)] outline-none ring-1 ring-border/40 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-h-[calc(100dvh-4rem)]",
+              className,
+            )}
+            {...props}
+          >
+            <DialogPrimitive.Close className="ring-offset-background absolute top-4 ltr:right-4 rtl:left-4 inline-flex size-9 items-center justify-center rounded-full border border-border/60 bg-background/95 text-muted-foreground shadow-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+            <div className="scrollbar-thin flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain">
+              {children}
+            </div>
+          </DialogPrimitive.Content>
         </div>
-      </DialogPrimitive.Content>
+      </div>
     </DialogPortal>
   );
 }
@@ -108,7 +120,10 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left sticky top-0 bg-background z-10 p-6 pb-4 border-b", className)}
+      className={cn(
+        "sticky top-0 z-10 flex flex-col gap-2 border-b border-border/60 bg-gradient-to-b from-background/92 via-background/95 to-background/98 p-6 pb-4 text-center shadow-[0_10px_30px_-20px_rgba(15,23,42,0.75)] sm:text-left",
+        className,
+      )}
       {...props}
     />
   );
@@ -119,7 +134,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sticky bottom-0 bg-background z-10 p-6 pt-4 border-t mt-auto",
+        "sticky bottom-0 mt-auto z-10 flex flex-col-reverse gap-2 border-t border-border/60 bg-gradient-to-t from-background/92 via-background/95 to-background/98 p-6 pt-4 shadow-[0_-10px_30px_-20px_rgba(15,23,42,0.65)] sm:flex-row sm:justify-end",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- synchronize the dialog root with controlled and uncontrolled usage while keeping body scroll locked when open
- deepen and blur the overlay backdrop so surrounding content darkens behind every modal
- rework the content wrapper to keep popups centered with rounded edges and internal scrolling on all screen sizes

## Testing
- (cd 'ازياء قرطبة' && npm run build)


------
https://chatgpt.com/codex/tasks/task_e_68cbec784b048328a20a188251d0f30c